### PR TITLE
Update: Remove deprecated Twig class

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Any HTML, inline CSS and Javascript will be compressed.
 First register the extension with Twig:
 
 ```php
-$twig = new Twig_Environment($loader);
+$twig = new \Twig\Environment($loader);
 $twig->addExtension(new \nochso\HtmlCompressTwig\Extension());
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,10 @@
     "keywords": ["html", "compress", "twig", "extension", "minify", "javascript", "css"],
     "type": "library",
     "license": "ISC",
-    "authors": [
-        {
-            "name": "Marcel Voigt",
-            "email": "mv@noch.so"
-        }
-    ],
+    "authors": [{
+        "name": "Marcel Voigt",
+        "email": "mv@noch.so"
+    }],
     "autoload": {
         "psr-4": {
             "nochso\\HtmlCompressTwig\\": "src/"
@@ -22,7 +20,7 @@
     },
     "require": {
         "wyrihaximus/html-compress": "^1.1",
-        "twig/twig": "^1.26 || ^2.0"
+        "twig/twig": "^2.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0"

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -10,8 +10,12 @@
 
 namespace nochso\HtmlCompressTwig;
 
-use Twig_Environment;
+
 use WyriHaximus\HtmlCompress\Factory;
+use Twig\Extension\AbstractExtension;
+use Twig\Environment;
+use Twig\TwigFunction;
+use Twig\TwigFilter;
 
 /**
  * Extension.
@@ -19,7 +23,7 @@ use WyriHaximus\HtmlCompress\Factory;
  * @author Marcel Voigt <mv@noch.so>
  * @copyright Copyright (c) 2015 Marcel Voigt <mv@noch.so>
  */
-class Extension extends \Twig_Extension
+class Extension extends AbstractExtension
 {
     /**
      * @var array
@@ -51,7 +55,7 @@ class Extension extends \Twig_Extension
         $this->callable = array($this, 'compress');
     }
 
-    public function compress(Twig_Environment $twig, $html)
+    public function compress(Environment $twig, $html)
     {
         if (!$twig->isDebug() || $this->forceCompression) {
             return $this->parser->compress($html);
@@ -69,14 +73,14 @@ class Extension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('htmlcompress', $this->callable, $this->options),
+            new TwigFunction('htmlcompress', $this->callable, $this->options),
         );
     }
 
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('htmlcompress', $this->callable, $this->options),
+            new TwigFilter('htmlcompress', $this->callable, $this->options),
         );
     }
 }

--- a/src/MinifyHtmlNode.php
+++ b/src/MinifyHtmlNode.php
@@ -10,16 +10,17 @@
 
 namespace nochso\HtmlCompressTwig;
 
-use Twig_Node;
+use Twig\Node\Node;
+use Twig\Compiler;
 
-class MinifyHtmlNode extends Twig_Node
+class MinifyHtmlNode extends Node
 {
     public function __construct(array $nodes = array(), array $attributes = array(), $lineno = 0, $tag = null)
     {
         parent::__construct($nodes, $attributes, $lineno, $tag);
     }
 
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $compiler
             ->addDebugInfo($this)

--- a/src/MinifyHtmlTokenParser.php
+++ b/src/MinifyHtmlTokenParser.php
@@ -10,18 +10,18 @@
 
 namespace nochso\HtmlCompressTwig;
 
-use Twig_Token;
-use Twig_TokenParser;
+use Twig\TokenParser\AbstractTokenParser;
+use Twig\Token;
 
-class MinifyHtmlTokenParser extends Twig_TokenParser
+class MinifyHtmlTokenParser extends AbstractTokenParser
 {
-    public function parse(Twig_Token $token)
+    public function parse(Token $token)
     {
         $lineNumber = $token->getLine();
         $stream = $this->parser->getStream();
-        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideHtmlCompressEnd'), true);
-        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $nodes = array('body' => $body);
         return new MinifyHtmlNode($nodes, array(), $lineNumber, $this->getTag());
     }
@@ -31,7 +31,7 @@ class MinifyHtmlTokenParser extends Twig_TokenParser
         return 'htmlcompress';
     }
 
-    public function decideHtmlCompressEnd(Twig_Token $token)
+    public function decideHtmlCompressEnd(Token $token)
     {
         return $token->test('endhtmlcompress');
     }

--- a/test/ExtensionTest.php
+++ b/test/ExtensionTest.php
@@ -13,9 +13,8 @@ namespace nochso\HtmlCompressTwig\test;
 use nochso\HtmlCompressTwig\Extension;
 use Twig\Loader\ArrayLoader;
 use Twig\Environment;
-use PHPUnit\Framework\TestCase;
 
-class ExtensionTest extends TestCase
+class ExtensionTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider htmlProvider

--- a/test/ExtensionTest.php
+++ b/test/ExtensionTest.php
@@ -11,16 +11,19 @@
 namespace nochso\HtmlCompressTwig\test;
 
 use nochso\HtmlCompressTwig\Extension;
+use Twig\Loader\ArrayLoader;
+use Twig\Environment;
+use PHPUnit\Framework\TestCase;
 
-class ExtensionTest extends \PHPUnit_Framework_TestCase
+class ExtensionTest extends TestCase
 {
     /**
      * @dataProvider htmlProvider
      */
     public function testExtensionMethod($template, $original, $compressed)
     {
-        $loader = new \Twig_Loader_Array(array('test' => $template));
-        $twig = new \Twig_Environment($loader);
+        $loader = new ArrayLoader(array('test' => $template));
+        $twig = new Environment($loader);
         $twig->addExtension(new Extension());
         $this->assertEquals($compressed, $twig->render('test'));
     }
@@ -52,8 +55,8 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoCompressionWhenDebug($template, $original, $compressed)
     {
-        $loader = new \Twig_Loader_Array(array('test' => $template));
-        $twig = new \Twig_Environment($loader, array('debug' => true));
+        $loader = new ArrayLoader(array('test' => $template));
+        $twig = new Environment($loader, array('debug' => true));
         $twig->addExtension(new Extension());
 
         // Assert no compression took place
@@ -65,8 +68,8 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testForceCompressionWhenDebug($template, $original, $compressed)
     {
-        $loader = new \Twig_Loader_Array(array('test' => $template));
-        $twig = new \Twig_Environment($loader, array('debug' => true));
+        $loader = new ArrayLoader(array('test' => $template));
+        $twig = new Environment($loader, array('debug' => true));
         $twig->addExtension(new Extension(true));
 
         // Assert that compression took place


### PR DESCRIPTION
update namespaces to support the latest version of twig